### PR TITLE
Adds a schema for photo content

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -48,14 +48,23 @@ export function createSchemas(options: SchemaOptions) {
 			.describe('the URL which the entry is considered a "repost" of')
 			.optional(),
 		/* Draft properties */
-		photo: safeUrl(options.site)
-			.or(z.array(safeUrl(options.site)))
+		photo: z
+			.string()
+			.or(safeUrl(options.site))
+			.or(z.string().or(z.array(safeUrl(options.site))))
 			.describe("one or more photos that is/are considered the primary content of the entry")
 			.optional(),
 		video: safeUrl(options.site)
-			.or(z.array(z.string().url()))
+			.or(z.string())
+			.or(z.string().or(z.array(safeUrl(options.site))))
 			.describe("one or more videos that is/are considered the primary content of the entry")
 			.optional(),
+	})
+
+	const photoSchema = baseSchema.extend({
+		name: z.string().describe("caption of the photo"),
+		summary: z.string().describe("description of the photo").optional(),
+		photo: safeUrl(options.site).describe("src URL for the original image file"),
 	})
 
 	const personSchema = z.object({
@@ -77,5 +86,6 @@ export function createSchemas(options: SchemaOptions) {
 		bookmarkSchema,
 		noteSchema,
 		personSchema,
+		photoSchema,
 	}
 }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -49,6 +49,7 @@ export function createSchemas(options: SchemaOptions) {
 			.optional(),
 		/* Draft properties */
 		photo: safeUrl(options.site)
+			.or(z.array(safeUrl(options.site)))
 			.describe("one or more photos that is/are considered the primary content of the entry")
 			.optional(),
 		video: safeUrl(options.site)


### PR DESCRIPTION
This adds a new `photoSchema` to the return type of `createSchemas`

> :warning: experimental!

The idea here is to treat assets as any other content - an image can have metadata like a caption or `alt` text, it should be captured along with the plain `src` string