### PR TITLE
feat: :fire: removes the site config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ What the hell does that mean? Runtime checks to make sure your `Note` is actuall
 ```ts
 import { createSchemas } from "@indiepub/core"
 
-const { articleSchema, bookmarkSchema, noteSchema, personSchema, photoSchema } = createSchemas({
-	site: "https://example.com",
-})
+const { articleSchema, bookmarkSchema, noteSchema, personSchema, photoSchema } = createSchemas()
 
 const article = articleSchema.parse({
 	name: "My awesome post",
@@ -47,35 +45,6 @@ const article2 = articleSchema.parse({
 	published: "2023-01-29T00:00:00Z",
 })
 ```
-
-### Configuration
-
-Only one option is required for now, that may change later!
-
-#### `options.site`
-
-This option is used to convert relative URLs to absolute URLs.
-
-```ts
-import { createSchemas } from "@indiepub/core"
-
-const { articleSchema, bookmarkSchema, noteSchema, personSchema } = createSchemas({
-	site: "https://example.com",
-})
-
-const article = articleSchema.parse({
-	name: "My awesome post",
-	featured: "/uploads/post-1-social.png",
-})
-```
-
-In the example above, `article.featured` is automatically parsed out to `https://example.com/uploads/post-1-social.png`.
-
-**Why?**
-
-For properties that really should be URLs, schemas validate that the string _looks_ like a URL. In the case of relative URLs, say a link that points to an image file in your project's `public` directory, the schema needs to try to convert this to a full URL for validation.
-
-This **does not** verify that the file in `public` exists, only that the provided string will parse out to a valid URL.
 
 ## How to contribute
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,11 +1,7 @@
 import { z } from "zod"
-import { safeDate, safeUrl } from "../utils"
+import { safeDate } from "../utils"
 
-export type SchemaOptions = {
-	site: string
-}
-
-export function createSchemas(options: SchemaOptions) {
+export function createSchemas() {
 	const baseSchema = z.object({
 		published: safeDate("when the entry was published").optional(),
 		updated: safeDate("when the entry was updated").optional(),
@@ -16,7 +12,8 @@ export function createSchemas(options: SchemaOptions) {
 	const articleSchema = baseSchema.extend({
 		name: z.string().describe("entry name/title"),
 		summary: z.string().describe("short entry summary").optional(),
-		featured: safeUrl(options.site)
+		featured: z
+			.string()
 			.describe("primary photo for an article suitable for use in a link preview")
 			.optional(),
 	})
@@ -50,13 +47,12 @@ export function createSchemas(options: SchemaOptions) {
 		/* Draft properties */
 		photo: z
 			.string()
-			.or(safeUrl(options.site))
-			.or(z.string().or(z.array(safeUrl(options.site))))
+			.or(z.array(z.string()))
 			.describe("one or more photos that is/are considered the primary content of the entry")
 			.optional(),
-		video: safeUrl(options.site)
-			.or(z.string())
-			.or(z.string().or(z.array(safeUrl(options.site))))
+		video: z
+			.string()
+			.or(z.array(z.string()))
 			.describe("one or more videos that is/are considered the primary content of the entry")
 			.optional(),
 	})
@@ -64,7 +60,7 @@ export function createSchemas(options: SchemaOptions) {
 	const photoSchema = baseSchema.extend({
 		name: z.string().describe("caption of the photo, often used for figure captions"),
 		summary: z.string().describe("description of the photo, often used for alt text").optional(),
-		photo: safeUrl(options.site).describe("src URL for the original image file"),
+		photo: z.string().describe("src URL for the original image file"),
 	})
 
 	const personSchema = z.object({
@@ -73,10 +69,13 @@ export function createSchemas(options: SchemaOptions) {
 		givenName: z.string().describe("given (often first) name").optional(),
 		familyName: z.string().describe("family (often last) name").optional(),
 		email: z.string().email().describe("email address").optional(),
-		logo: safeUrl(options.site)
+		logo: z
+			.string()
 			.describe("a logo representing the person or organization, e.g. avatar icon")
 			.optional(),
-		url: safeUrl(options.site)
+		url: z
+			.string()
+			.url()
 			.describe("home page or other URL representing the person or organization")
 			.optional(),
 	})


### PR DESCRIPTION
Turns out `options.site` was too opinionated, it makes storing local files and relative paths impossible.  Removing this to leave it up to the user of `@indiepub/core` to manage URLs in the way they expect it