### PR TITLE
feat: :sparkles: adds support for article.uid for canonical URLs

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -16,6 +16,13 @@ export function createSchemas() {
 			.string()
 			.describe("primary photo for an article suitable for use in a link preview")
 			.optional(),
+		uid: z
+			.string()
+			.url()
+			.describe(
+				"canonical URL for the article, used if the article was originally published on another site",
+			)
+			.optional(),
 	})
 
 	const bookmarkSchema = baseSchema.extend({


### PR DESCRIPTION
Based on the [h-entry spec](https://microformats.org/wiki/h-entry#Properties), this adds the `uid` field to articles to support canonical URLs